### PR TITLE
Fixed position_tracker bug and added new VisMapGenerator features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+venv/

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -117,3 +117,18 @@ def generate(
 
     return vismap, position_tracker
     pass
+
+def flip_h(
+    vismap: Vismap, 
+    position_map: list[tuple[int,int,int]]
+) -> tuple[Vismap,PositionTracker]:
+    flipped_vismap = [list(reversed(column)) for column in vismap]
+    
+    column_count = len(vismap)
+    flipped_positions = [
+        (column_count-1-x,y,z) 
+        for x,y,z in position_map
+    ]
+    
+    return flipped_vismap, flipped_positions
+    pass

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -99,13 +99,13 @@ def generate(
         # Adding vismap entry if doing so will not cause two intersections to overlay
         # This is done so that the vismap doesn't always have two intersections for every intersection that exists
         working_cell = vismap[head[0]][head[1]]
+        position_tracker.append((head[0],head[1],len(working_cell)))
         if not(piece.type == TrackPieceTypes.INTERSECTION 
         and len(working_cell) > 0
         and all([
             check.piece.type == TrackPieceTypes.INTERSECTION 
             for check in working_cell
         ])):
-            position_tracker.append((head[0],head[1],len(working_cell)))
             working_cell.append(Element(piece,orientation))
             pass
         else:

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -7,6 +7,7 @@ __all__ = ("generate")
 
 
 Vismap = list[list[list["Element"]]]
+PositionTracker = list[tuple[int,int,int]]
 Orientation = tuple[Literal[-1,0,1],Literal[-1,0,1]]
 
 @dataclass(repr=False,frozen=True,slots=True)
@@ -53,8 +54,14 @@ def _expand_down(vismap: Vismap):
         pass
     pass
 
-def generate(track_map: list[TrackPiece]) -> tuple[Vismap,list[tuple[int,int,int]]]:
+def generate(
+    track_map: list[TrackPiece],
+    orientation: tuple[int,int] = (1,0)
+) -> tuple[Vismap,PositionTracker]:
     """Creates a 3d map of the track from the 1d version passed as an argument"""
+    if orientation not in _ORIENTATIONS:
+        raise ValueError(f"Passed orientation is not valid. Must be one of {_ORIENTATIONS}")
+
     vismap: Vismap = [[[]]]
     position_tracker = []
 

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -66,7 +66,6 @@ def generate(
     position_tracker = []
 
     head = [0,0]
-    orientation = (1,0)
     for piece in track_map:
         head[0] += orientation[0]
         head[1] += orientation[1]

--- a/examplemap.py
+++ b/examplemap.py
@@ -1,31 +1,38 @@
 from anki import TrackPiece, TrackPieceTypes
 from anki.utility.const import RawTrackPieces
 
-def g(vals, clockwise = 0):
-    return TrackPiece(0,vals[0],clockwise)
+def g(type_: TrackPieceTypes, clockwise: bool = False):
+    return TrackPiece(0,type_,clockwise)
     pass
 
-START = RawTrackPieces.START
-CURVE = RawTrackPieces.CURVE
-STRAIGHT = RawTrackPieces.STRAIGHT
-INTERSECTION = RawTrackPieces.INTERSECTION
-FINISH = RawTrackPieces.FINISH
+START = TrackPieceTypes.START
+FINISH = TrackPieceTypes.FINISH
+CURVE = TrackPieceTypes.CURVE
+STRAIGHT = TrackPieceTypes.STRAIGHT
+INTERSECTION = TrackPieceTypes.INTERSECTION
 
 map = (
     g(START),
-    g(CURVE,255),
-    g(INTERSECTION),
-    g(INTERSECTION),
-    g(CURVE,255),
+    g(CURVE,False),
+    g(CURVE,False),
     g(STRAIGHT),
-    g(CURVE,255),
     g(INTERSECTION),
-    g(CURVE,255),
-    g(CURVE,255),
+    g(INTERSECTION),
+    g(CURVE,True),
+    g(CURVE,True),
+    g(STRAIGHT),
+    g(INTERSECTION),
+    g(CURVE,True),
+    g(STRAIGHT),
+    g(CURVE,True),
+    g(STRAIGHT),
+    g(CURVE,True),
     g(INTERSECTION),
     g(STRAIGHT),
-    g(CURVE,255),
-    g(STRAIGHT),
-    g(CURVE,255),
+    g(CURVE,True),
+    g(CURVE,True),
+    g(INTERSECTION),
+    g(INTERSECTION),
+    g(CURVE,False),
     g(FINISH)
 )

--- a/vismap test.py
+++ b/vismap test.py
@@ -1,0 +1,21 @@
+from VisMapGenerator import generate
+from examplemap import map
+from anki import TrackPieceTypes
+
+lookup = {
+    TrackPieceTypes.FINISH : "F",
+    TrackPieceTypes.START : "F",
+    TrackPieceTypes.CURVE : "C",
+    TrackPieceTypes.STRAIGHT : "S",
+    TrackPieceTypes.INTERSECTION : "I"
+}
+
+vismap, _ = generate(map,(1,0))
+
+for row in zip(*vismap):
+    print(
+        *[
+            str.center("".join([lookup[e.piece.type] for e in cell]),3) 
+            for cell in row
+        ]
+    )


### PR DESCRIPTION
This pull request includes several changes in `VisMapGenerator.py`:

- A new argument `orientation`, indicates the starting orientation of the vismap and may be any value of `_ORIENTATIONS`. It is `(1,0)` by default. This change is not a breaking change.
- Added a new function `flip_h`, which requires both returns of `generate` and flips the map at the vertical axis.
- Fixed a bug that would cause the position tracker to desync at intersections.

The following changes were also made:
- `.gitignore`: Added `venv/` to gitignore.
- `examplemap.py` updated the example map to work with the current py-drivesdk version. Also made the track more complex. (It now reflects our debug track)