### PR TITLE
Expanded UI API to allow fixing RuntimeWarnings in addEvent

### DIFF
--- a/UiMain.py
+++ b/UiMain.py
@@ -12,7 +12,7 @@ import anki
 from anki import TrackPieceType
 from anki.misc.lanes import BaseLane
 
-import Design
+from Design import Design
 from VehicleControlWindow import vehicleControler
 from helpers import *
 
@@ -33,7 +33,7 @@ class Ui:
             showControler: bool = False,
             fps: int = 60,
             customLanes: list[BaseLane] = [], 
-            Design: Design.Design = Design.Design(),
+            design: Design = Design(),
             vehicleColors: Iterable[tuple[int,int,int]] = []
         ) -> None:
         self._vehicleColorIterator = itertools.chain(
@@ -57,11 +57,11 @@ class Ui:
         self.showUi = showUi
         self.fps = fps
         self._carInfoOffset = 0
-        self._Design = Design
+        self._design = design
         
         #starting pygame
         pygame.init()
-        self._font = pygame.font.SysFont(Design.Font,Design.FontSize)
+        self._font = pygame.font.SysFont(design.Font, design.FontSize)
         # integrated event logging
         self._eventSurf: pygame.Surface|None = None
         #Ui surfaces
@@ -98,10 +98,10 @@ class Ui:
     def genGrid(self,visMap,mapsurf)-> pygame.Surface:
         drawGridLine = lambda start, end: pygame.draw.line(
             mapsurf,
-            self._Design.Line,
+            self._design.Line,
             start,
             end,
-            self._Design.LineWidth
+            self._design.LineWidth
         )
         for x in range(1,len(visMap)):
             drawGridLine((x*100,0), (x*100,len(visMap[x])*100))
@@ -144,21 +144,21 @@ class Ui:
                         case TrackPieceType.FINISH:
                             pass
         self._visMapSurf = mapSurf
-        if self._Design.ShowGrid:
+        if self._design.ShowGrid:
             self._visMapSurf = self.genGrid(visMap,mapSurf)
-        if self._Design.ShowOutlines:
-            pygame.draw.rect(self._visMapSurf,self._Design.Line,(0,0,len(visMap)*100, len(visMap[0])*100),self._Design.LineWidth)
+        if self._design.ShowOutlines:
+            pygame.draw.rect(self._visMapSurf,self._design.Line,(0,0,len(visMap)*100, len(visMap[0])*100),self._design.LineWidth)
     
     #infos for cars
     def _blitCarInfoOnSurface(self, surf: pygame.Surface, text: str, dest: tuple[int, int]):
         surf.blit(
-            self._font.render(text, True, self._Design.Text),
+            self._font.render(text, True, self._design.Text),
             (10+dest[0]*300,
-            10+self._Design.FontSize*dest[1])
+            10+self._design.FontSize*dest[1])
         )
     def carInfo(self, vehicle: anki.Vehicle, number:int) -> pygame.Surface:
-        surf = pygame.surface.Surface((CAR_INFO_WIDTH,20+self._Design.FontSize*4))
-        surf.fill(self._Design.CarInfoFill)
+        surf = pygame.surface.Surface((CAR_INFO_WIDTH,20+self._design.FontSize*4))
+        surf.fill(self._design.CarInfoFill)
         try:
             self._blitCarInfoOnSurface(surf, f"Vehicle ID: {vehicle.id}",(0,0))
             self._blitCarInfoOnSurface(surf, f"Number: {number}",(1,0))
@@ -168,15 +168,15 @@ class Ui:
             self._blitCarInfoOnSurface(surf, f"Speed: {round(vehicle.speed,2)}", (1,2))
             self._blitCarInfoOnSurface(surf, f"Trackpiece: {vehicle.current_track_piece.type.name}",(0,3))
             pygame.draw.circle(surf,self._accumulatedVehicleColors[number],
-                               (CAR_INFO_WIDTH-10-self._Design.FontSize/2,10+self._Design.FontSize*3.5),
-                               self._Design.FontSize/2)
+                               (CAR_INFO_WIDTH-10-self._design.FontSize/2,10+self._design.FontSize*3.5),
+                               self._design.FontSize/2)
         except Exception as e:
-            surf.fill(self._Design.CarInfoFill)
+            surf.fill(self._design.CarInfoFill)
             self._blitCarInfoOnSurface(surf, f"Invalid information:", (0,0))
             self._blitCarInfoOnSurface(surf, f"{e}", (0,1))
             warnings.warn(e)
-        if self._Design.ShowOutlines:
-            pygame.draw.rect(surf,self._Design.Line,surf.get_rect(),self._Design.LineWidth)
+        if self._design.ShowOutlines:
+            pygame.draw.rect(surf,self._design.Line,surf.get_rect(),self._design.LineWidth)
         return surf
     def carOnMap(self) ->pygame.Surface:
         maping = []
@@ -198,7 +198,7 @@ class Ui:
                         text = self._font.render(
                             f"{current}",
                             True,
-                            self._Design.CarPosText
+                            self._design.CarPosText
                         )
                         width += text.get_width()
                         surf.blit(
@@ -265,21 +265,21 @@ class Ui:
         # NOTE: Pygame sucks. You can't render fonts with translucent background.
         # You _can_ render fonts with transparent background though, 
         # so this blitting nonsense works while a background colour doesn't.
-        BtnText = self._font.render("Controller",True,self._Design.Text)
+        BtnText = self._font.render("Controller",True,self._design.Text)
         Button = pygame.surface.Surface(BtnText.get_size(),pygame.SRCALPHA)
-        Button.fill(self._Design.ButtonFill)
+        Button.fill(self._design.ButtonFill)
         BtnRect = BtnText.get_rect()
-        if self._Design.ShowOutlines:
+        if self._design.ShowOutlines:
             pygame.draw.rect(
                 Button,
-                self._Design.Line,
+                self._design.Line,
                 BtnRect,
-                self._Design.LineWidth
+                self._design.LineWidth
             )
         Button.blit(BtnText,(0,0))
         
-        UpArrow = self._font.render("\u25b2",True,self._Design.Text)
-        DownArrow = self._font.render("\u25bc", True,self._Design.Text)
+        UpArrow = self._font.render("\u25b2",True,self._design.Text)
+        DownArrow = self._font.render("\u25bc", True,self._design.Text)
         
         UpRect = UpArrow.get_rect()
         UpRect.topright = (self._visMapSurf.get_width(), 0)
@@ -291,7 +291,7 @@ class Ui:
             (UpArrow.get_width(),UpArrow.get_height()+DownArrow.get_height()),
             pygame.SRCALPHA
         )
-        ScrollSurf.fill(self._Design.ButtonFill)
+        ScrollSurf.fill(self._design.ButtonFill)
         ScrollSurf.blit(UpArrow,(0,0))
         ScrollSurf.blit(DownArrow,(0,UpArrow.get_height()))
         
@@ -300,16 +300,16 @@ class Ui:
     
     
     def updateUi(self):
-        self.UiSurf.fill(self._Design.Background)
+        self.UiSurf.fill(self._design.Background)
         self.UiSurf.blit(self._visMapSurf,(0,0))
         
         self.UiSurf.blit(self._eventSurf,(0,self._visMapSurf.get_height()))
-        if self._Design.ShowOutlines:
+        if self._design.ShowOutlines:
             pygame.draw.rect(
                 self._eventSurf,
-                self._Design.Line,
+                self._design.Line,
                 self._eventSurf.get_rect(),
-                self._Design.LineWidth
+                self._design.LineWidth
             )
         
         carInfoSurfs = self.getCarSurfs()
@@ -317,9 +317,9 @@ class Ui:
         for i, carInfoSurf in enumerate(carInfoSurfs):
             self.UiSurf.blit(carInfoSurf,(self._visMapSurf.get_width(),carInfoSurf.get_height()*i))
         
-        if(self._Design.ShowCarNumOnMap):
+        if(self._design.ShowCarNumOnMap):
             self.UiSurf.blit(self.carOnMap(),(0,0))
-        if(self._Design.ShowCarOnStreet):
+        if(self._design.ShowCarOnStreet):
             self.UiSurf.blit(self.carOnStreet(),(0,0))
     
     #The Code that showeth the Ui (:D)
@@ -327,13 +327,13 @@ class Ui:
         self.gen_MapSurface(self._visMap)
         self._eventSurf = pygame.Surface((
             self._visMapSurf.get_width(),
-            self._Design.ConsoleHeight
+            self._design.ConsoleHeight
         ))
-        self._eventSurf.fill(self._Design.EventFill)
-        self.addEvent("Started Ui",self._Design.Text)
+        self._eventSurf.fill(self._design.EventFill)
+        self.addEvent("Started Ui",self._design.Text)
         uiSize = (
             self._visMapSurf.get_width() + CAR_INFO_WIDTH,
-            self._visMapSurf.get_height() + self._Design.ConsoleHeight
+            self._visMapSurf.get_height() + self._design.ConsoleHeight
         )
         if self.showUi:
             Logo = load_image("Logo.png")
@@ -386,12 +386,12 @@ class Ui:
             text,
             True,
             color if color != None else (0,0,0),
-            self._Design.EventFill
+            self._design.EventFill
         )
         #The lines between messages when using outlines apear due to using scroll 
         # this is seen as a feature
         self._eventSurf.scroll(dy=event.get_height())
-        pygame.draw.rect(self._eventSurf,self._Design.EventFill,
+        pygame.draw.rect(self._eventSurf,self._design.EventFill,
                          (0,0,self._eventSurf.get_width(),event.get_height()))
         self._eventSurf.blit(event, (10, 0))
     def getUiSurf(self) -> pygame.Surface: 
@@ -409,7 +409,7 @@ class Ui:
         self.gen_MapSurface(self._visMap)
         self.UiSurf = pygame.surface.Surface(
             (self._visMapSurf.get_width() + self.getCarSurfs()[0].get_width(),
-                self._visMapSurf.get_height() + self._Design.ConsoleHeight))
+                self._visMapSurf.get_height() + self._design.ConsoleHeight))
         if(self.showUi):
             self._ControlButtonSurf, self._ScrollSurf = self.gen_Buttons()
         
@@ -417,11 +417,11 @@ class Ui:
         # TODO: Fix code duplication with _UiThread
         self._eventSurf = pygame.Surface((
             self._visMapSurf.get_width(),
-            self._Design.ConsoleHeight
+            self._design.ConsoleHeight
         ))
         self._eventSurf.blit(old_eventSurf, (0, 0))
-    def setDesign(self,Design: Design.Design):
-        self._Design = Design
+    def setDesign(self, design: Design):
+        self._design = design
         self.updateDesign()
     
     def addVehicle(

--- a/UiMain.py
+++ b/UiMain.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 import math
-from typing import Iterable
+from typing import Iterable, Self
 import warnings
 import threading
 import concurrent.futures
@@ -80,6 +80,15 @@ class Ui:
             self.startControler()
         
         self._carIMG = load_image(relative_to_file("Fahrzeug.png"))
+    
+    @classmethod
+    def fromController(
+        cls,
+        controller: anki.Controller,
+        orientation: tuple[int,int],
+        **kwargs
+    ):
+        return cls(list(controller.vehicles), controller.map, orientation, **kwargs)
     
     #generating vismap
     def genGrid(self,visMap,mapsurf)-> pygame.Surface:

--- a/UiMain.py
+++ b/UiMain.py
@@ -24,12 +24,18 @@ except ImportError:
 CAR_INFO_WIDTH = 500
 
 class Ui:    
-    def __init__(self, vehicles: list[anki.Vehicle], 
-                 map,orientation :tuple[int,int],flipMap: bool =False,
-                 showUi:bool = True,showControler:bool = False, fps: int = 60,
-                 customLanes:list[BaseLane]=[], 
-                 Design:Design.Design = Design.Design(),
-                 vehicleColors:Iterable[tuple[int,int,int]]= []) -> None:
+    def __init__(self,
+            vehicles: list[anki.Vehicle], 
+            map,
+            orientation: tuple[int,int] = (1,0),
+            flipMap: bool = False,
+            showUi: bool = True,
+            showControler: bool = False,
+            fps: int = 60,
+            customLanes: list[BaseLane] = [], 
+            Design: Design.Design = Design.Design(),
+            vehicleColors: Iterable[tuple[int,int,int]] = []
+        ) -> None:
         self._vehicleColorIterator = itertools.chain(
             iter(vehicleColors), 
             itertools.repeat((255,255,255))
@@ -82,13 +88,11 @@ class Ui:
         self._carIMG = load_image(relative_to_file("Fahrzeug.png"))
     
     @classmethod
-    def fromController(
-        cls,
+    def fromController(cls,
         controller: anki.Controller,
-        orientation: tuple[int,int],
         **kwargs
     ):
-        return cls(list(controller.vehicles), controller.map, orientation, **kwargs)
+        return cls(list(controller.vehicles), controller.map, **kwargs)
     
     #generating vismap
     def genGrid(self,visMap,mapsurf)-> pygame.Surface:

--- a/UiMain.py
+++ b/UiMain.py
@@ -424,7 +424,7 @@ class Ui:
     
     def removeVehicle(self,index: int):
         self._vehicles.pop(index)
-        self._vehicleColors.pop(index)
+        self._accumulatedVehicleColors.pop(index)
     
     def startControler(self): #modify starting condition
         if self._controlThread is None or not self._controlThread.is_alive():

--- a/UiMain.py
+++ b/UiMain.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     from VisMapGenerator import generate, flip_h, Vismap
 
+CAR_INFO_WIDTH = 500
 
 class Ui:    
     def __init__(self, vehicles: list[anki.Vehicle], 
@@ -139,7 +140,7 @@ class Ui:
             10+self._Design.FontSize*dest[1])
         )
     def carInfo(self, vehicle: anki.Vehicle, number:int) -> pygame.Surface:
-        surf = pygame.surface.Surface((500,20+self._Design.FontSize*4))
+        surf = pygame.surface.Surface((CAR_INFO_WIDTH,20+self._Design.FontSize*4))
         surf.fill(self._Design.CarInfoFill)
         try:
             self._blitCarInfoOnSurface(surf, f"Vehicle ID: {vehicle.id}",(0,0))
@@ -150,7 +151,7 @@ class Ui:
             self._blitCarInfoOnSurface(surf, f"Speed: {round(vehicle.speed,2)}", (1,2))
             self._blitCarInfoOnSurface(surf, f"Trackpiece: {vehicle.current_track_piece.type.name}",(0,3))
             pygame.draw.circle(surf,self._accumulatedVehicleColors[number],
-                               (500-10-self._Design.FontSize/2,10+self._Design.FontSize*3.5),
+                               (CAR_INFO_WIDTH-10-self._Design.FontSize/2,10+self._Design.FontSize*3.5),
                                self._Design.FontSize/2)
         except Exception as e:
             surf.fill(self._Design.CarInfoFill)
@@ -314,7 +315,7 @@ class Ui:
         self._eventSurf.fill(self._Design.EventFill)
         self.addEvent("Started Ui",self._Design.Text)
         uiSize = (
-            self._visMapSurf.get_width() + self.getCarSurfs()[0].get_width(),
+            self._visMapSurf.get_width() + CAR_INFO_WIDTH,
             self._visMapSurf.get_height() + self._Design.ConsoleHeight
         )
         if self.showUi:

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -14,17 +14,16 @@ Orientation = tuple[Literal[-1,0,1],Literal[-1,0,1]]
 class Element:
     piece: TrackPiece
     orientation: Orientation
-    rotation: int|None = None
-    flipped: bool|None = None
+    rotation: int
 
     def __repr__(self):
-        return f"{type(self).__qualname__}({self.piece.type.name},{self.orientation}[{self.rotation},{self.flipped}])"
+        return f"{type(self).__qualname__}({self.piece.type.name},{self.orientation}[{self.rotation}])"
         pass
     def __str__(self):
         return repr(self)
     pass
 
-_ORIENTATIONS: tuple[Orientation,...]=((1,0),(0,-1),(-1,0),(0,1))
+_ORIENTATIONS: tuple[Orientation,...] = ((1,0),(0,-1),(-1,0),(0,1))
 def _next_orientation(orientation: Orientation, is_clockwise: bool) -> Orientation:
     new_index = _ORIENTATIONS.index(orientation) + (1 if not is_clockwise else -1)
     return _ORIENTATIONS[new_index%len(_ORIENTATIONS)]
@@ -85,12 +84,11 @@ piece orientation. The previous piece orientation has to be inverted.
 """
 
 def orientation_to_rotation(
-    type,
+    type: TrackPieceType,
     orientation: Orientation, 
     previous_orientation: Orientation
-) -> tuple[int,bool]:
+) -> int:
     if type == TrackPieceType.CURVE:
-        flipped = False
         try:
             rotation = _CURVE_ROTATIONS_LOOKUP[
                 (orientation,_invert_orientation(previous_orientation))
@@ -101,17 +99,16 @@ def orientation_to_rotation(
             rotation = _CURVE_ROTATIONS_LOOKUP[
                 (_invert_orientation(previous_orientation),orientation)
             ]
-            flipped = False
-        return rotation, flipped
+        return rotation
         pass
     elif type in (
         TrackPieceType.STRAIGHT,
         TrackPieceType.START,
         TrackPieceType.FINISH
     ):
-        return _ORIENTATIONS.index(orientation)*90, False
+        return _ORIENTATIONS.index(orientation)*90
     elif type == TrackPieceType.INTERSECTION:
-        return 0, False
+        return 0
     else:
         raise RuntimeError
     pass
@@ -172,7 +169,7 @@ def generate(
             working_cell.append(Element(
                 piece,
                 orientation,
-                *orientation_to_rotation(
+                orientation_to_rotation(
                     piece.type,
                     orientation,
                     previous_orientation
@@ -187,7 +184,7 @@ def generate(
             working_cell.append(Element(
                 piece,
                 orientation,
-                *orientation_to_rotation(
+                orientation_to_rotation(
                     piece.type,
                     orientation,
                     previous_orientation
@@ -199,7 +196,8 @@ def generate(
     return vismap, position_tracker
     pass
 
-def h_rotation_flip(r: int) -> int: return 90-(r%180) + (r//180)*180
+def h_rotation_flip(r: int) -> int: 
+    return 90 - (r%180) + (r//180)*180
 
 def flip_h(
     vismap: Vismap, 
@@ -211,7 +209,7 @@ def flip_h(
                 Element(
                     e.piece,
                     (-e.orientation[0],e.orientation[1]),
-                    h_rotation_flip(e.rotation) # type: ignore
+                    h_rotation_flip(e.rotation)
                 )
                 for e in position
             ]

--- a/__main__.py
+++ b/__main__.py
@@ -18,6 +18,7 @@ async def main():
         #autos[0]._position = 0
         await control.scan() # type: ignore
         with Ui(list(autos),control.map,(1,0),False) as Uiob:
+            await Uiob.waitForSetupAsync() # Ensure addEvent is called only after successful setup.
             Uiob.addEvent("test")
             while True:
                 await asyncio.sleep(10)


### PR DESCRIPTION
Previously calling an addEvent soon after entering the Ui context (see below) would cause a RuntimeWarning to be issued due to a race condition between the ui and main thread. 
```py
# ...
with Ui.fromController(controller) as obj:
  await obj.waitForSetupAsync()
  obj.addEvent("Hello World!")
```
_obj.addEvent will no longer emit a `RuntimeWarning` with addition of `Ui.waitForSetupAsync`_

Additionally a bug has been fixed where `Ui.removeVehicle` would fail due to a missed renaming and `Ui.fromController` has been added, which allows a much shorter initialisation. Additionally `orientation` is now an optional parameter defaulting to `(0,1` and `Design` variables have now been changed to `design` across the codebase.

These changes should improve the code `Design: Design.Design = Design.Design()`