### PR TITLE
Fixed #9 and code improvements

### DIFF
--- a/UiMain.py
+++ b/UiMain.py
@@ -31,7 +31,7 @@ class Ui:
             flip: tuple[bool, bool] = (False, False),
             showUi: bool = True,
             showControler: bool = False,
-            fps: int = 60,
+            fps: int = 10,
             customLanes: list[BaseLane] = [], 
             design: Design = Design(),
             vehicleColors: Iterable[tuple[int,int,int]] = []

--- a/UiMain.py
+++ b/UiMain.py
@@ -28,7 +28,7 @@ class Ui:
             vehicles: list[anki.Vehicle], 
             map,
             orientation: tuple[int,int] = (1,0),
-            flipMap: bool = False,
+            flip: tuple[bool, bool] = (False, False),
             showUi: bool = True,
             showControler: bool = False,
             fps: int = 60,
@@ -49,11 +49,20 @@ class Ui:
         self._customLanes = customLanes + anki.Lane3.getAll() + anki.Lane4.getAll()
         self._laneSystem = BaseLane("CustomLanes",{lane.name:lane.value for lane in self._customLanes})
         #setting up map
+        flip_horizontal = flip[0]
+        if flip[1]:
+            # Vertical flipping is 180° rotation with horizontal flipping
+            flip_horizontal = not flip_horizontal
+            orientation = (-orientation[0], -orientation[1])
+
         self._map = map
         self._visMap, self._lookup = generate(self._map, orientation)
-        if flipMap:
-            self._visMap, self._lookup = flip_h(self._visMap,self._lookup)
-            #loading aditional information
+        
+        if flip_horizontal:
+            self._visMap, self._lookup = flip_h(self._visMap, self._lookup)
+
+        
+        #loading aditional information
         self.showUi = showUi
         self.fps = fps
         self._carInfoOffset = 0

--- a/UiMain.py
+++ b/UiMain.py
@@ -1,7 +1,6 @@
 import itertools
-import os
 import math
-from typing import Iterable, Self
+from typing import Iterable
 import warnings
 import threading
 import concurrent.futures
@@ -123,35 +122,34 @@ class Ui:
         Kreuzung = load_image("Kreuzung.png")
         Start = load_image("Start.png")
         mapSurf = pygame.surface.Surface((len(visMap)*100, len(visMap[0])*100),pygame.SRCALPHA)
-        for x, column in enumerate(visMap):
-            for y, layers in enumerate(column):
-                for i, current in enumerate(layers):
-                    match current.piece.type:
-                        case TrackPieceType.STRAIGHT:
-                            Gerade.set_alpha(int((1.5**-i)*255))
-                            mapSurf.blit(
-                                rotateSurf(Gerade,current.orientation,90),
-                                (x*100,y*100)
-                            )
-                            # mapSurf.blit(self._font.render(f"{current.orientation}",True,(100,100,100)),(x*100,y*100))
-                        case TrackPieceType.CURVE:
-                            Kurve.set_alpha(int((1.5**-i)*255))
-                            mapSurf.blit(pygame.transform.rotate(Kurve,float(current.rotation)),(x*100,y*100)) # type: ignore
-                            #mapSurf.blit(self._font.render(
-                            #    f"{current.rotation} {current.orientation} {int(current.flipped) if current.flipped is not None else '/'}",
-                            #    True,
-                            #    (100,100,100)
-                            #),(x*100,y*100))
-                        case TrackPieceType.INTERSECTION:
-                            if current.orientation[0] != 0:
-                                Kreuzung.set_alpha(int((1.5**-i)*255))
-                                mapSurf.blit(Kreuzung, (x*100,y*100))
-                        case TrackPieceType.START:
-                            Start.set_alpha(int((1.5**-i)*255))
-                            mapSurf.blit(rotateSurf(Start,current.orientation,90),(x*100,y*100))
-                            # mapSurf.blit(self._font.render(f"{current.orientation}",True,(100,100,100)),(x*100,y*100))
-                        case TrackPieceType.FINISH:
-                            pass
+        for (i, y, x), current in enumerated_flatten(visMap):
+            current: Element
+            match current.piece.type:
+                case TrackPieceType.STRAIGHT:
+                    Gerade.set_alpha(int((1.5**-i)*255))
+                    mapSurf.blit(
+                        rotateSurf(Gerade,current.orientation,90),
+                        (x*100,y*100)
+                    )
+                    # mapSurf.blit(self._font.render(f"{current.orientation}",True,(100,100,100)),(x*100,y*100))
+                case TrackPieceType.CURVE:
+                    Kurve.set_alpha(int((1.5**-i)*255))
+                    mapSurf.blit(pygame.transform.rotate(Kurve,float(current.rotation)),(x*100,y*100)) # type: ignore
+                    #mapSurf.blit(self._font.render(
+                    #    f"{current.rotation} {current.orientation} {int(current.flipped) if current.flipped is not None else '/'}",
+                    #    True,
+                    #    (100,100,100)
+                    #),(x*100,y*100))
+                case TrackPieceType.INTERSECTION:
+                    if current.orientation[0] != 0:
+                        Kreuzung.set_alpha(int((1.5**-i)*255))
+                        mapSurf.blit(Kreuzung, (x*100,y*100))
+                case TrackPieceType.START:
+                    Start.set_alpha(int((1.5**-i)*255))
+                    mapSurf.blit(rotateSurf(Start,current.orientation,90),(x*100,y*100))
+                    # mapSurf.blit(self._font.render(f"{current.orientation}",True,(100,100,100)),(x*100,y*100))
+                case TrackPieceType.FINISH:
+                    pass
         self._visMapSurf = mapSurf
         if self._design.ShowGrid:
             self._visMapSurf = self.genGrid(visMap,mapSurf)
@@ -201,20 +199,19 @@ class Ui:
         
         for x, column in enumerate(maping):
             for y, layers in enumerate(column):
-                if (layers != []):
-                    width = 0
-                    for i, current in enumerate(layers):
-                        text = self._font.render(
-                            f"{current}",
-                            True,
-                            self._design.CarPosText
-                        )
-                        width += text.get_width()
-                        surf.blit(
-                            text,
-                            (x*100+100-width,y*100+100-text.get_height())
-                        )
-                        #pygame.draw.rect(surf,(0,0,0),(x*100+100-10*(i+1),y*100+90,10,10),1)
+                width = 0
+                for i, current in enumerate(layers):
+                    text = self._font.render(
+                        f"{current}",
+                        True,
+                        self._design.CarPosText
+                    )
+                    width += text.get_width()
+                    surf.blit(
+                        text,
+                        (x*100+100-width,y*100+100-text.get_height())
+                    )
+                    #pygame.draw.rect(surf,(0,0,0),(x*100+100-10*(i+1),y*100+90,10,10),1)
         return surf
     def carOnStreet(self) -> pygame.Surface:
         rotationToDirection:dict[int,tuple[int,int]]= {

--- a/UiMain.py
+++ b/UiMain.py
@@ -152,7 +152,7 @@ class Ui:
             pygame.draw.circle(surf,self._accumulatedVehicleColors[number],
                                (500-10-self._Design.FontSize/2,10+self._Design.FontSize*3.5),
                                self._Design.FontSize/2)
-        except Exception as e:
+        except (AttributeError, TypeError) as e:
             surf.fill(self._Design.CarInfoFill)
             self._blitCarInfoOnSurface(surf, f"Invalid information:", (0,0))
             self._blitCarInfoOnSurface(surf, f"{e}", (0,1))

--- a/VisMapGenerator.py
+++ b/VisMapGenerator.py
@@ -196,8 +196,14 @@ def generate(
     return vismap, position_tracker
     pass
 
+ROTATION_FLIP_MAP = {
+    0: 90,
+    90: 0,
+    180: 270,
+    270: 180
+}
 def h_rotation_flip(r: int) -> int: 
-    return 90 - (r%180) + (r//180)*180
+    return ROTATION_FLIP_MAP[r]
 
 def flip_h(
     vismap: Vismap, 
@@ -213,9 +219,9 @@ def flip_h(
                 )
                 for e in position
             ]
-            for position in reversed(column)
+            for position in column
         ] 
-        for column in vismap
+        for column in reversed(vismap)
     ]
     
     column_count = len(vismap)

--- a/__main__.py
+++ b/__main__.py
@@ -18,8 +18,7 @@ async def main():
         autos = await control.connect_many(1)
         #autos[0]._position = 0
         await control.scan() # type: ignore
-        with Ui(list(autos),control.map,(1,0),False,fps=10,
-                vehicleColors=[(255,0,0)]) as Uiob:
+        with Ui.fromController(control, orientation=(0, -1), flip=(False, True)) as Uiob:
             await Uiob.waitForSetupAsync() # Ensure addEvent is called only after successful setup.
             Uiob.addEvent("test")
             while True:

--- a/helpers.py
+++ b/helpers.py
@@ -1,6 +1,11 @@
 import os
 import pygame
 import math
+from typing import Iterable, Sequence, TypeVar, Generator, Any
+
+T = TypeVar('T')
+NestedIterable = Iterable["T|NestedIterable[T]"]
+NestedSequence = Sequence["T|NestedSequence[T]"]
 
 def relative_to_file(relpath: str) -> str:
     return os.path.join(
@@ -16,3 +21,47 @@ def rotateSurf(surf: pygame.Surface, orientation: tuple[int,int],addition:int=0)
         surf,
         math.degrees(math.atan2(-orientation[1],orientation[0]))+addition
     )
+
+def flatten(iterable: NestedIterable|T) -> Iterable[T]:
+    """
+    Flattens a nested iterable with depth n 
+    and potentially non-uniform shape into a
+    depth-first iterable of each element.
+
+    e. g. `( (1, 2), (3, 4) )`
+    is flattened to `(1, 2, 3, 4)`
+    (as an iterator)
+    """
+    if isinstance(iterable, Iterable):
+        for v in iterable:
+            yield from flatten(v)
+    else:
+        yield iterable
+
+def enumerated_flatten(iterable: NestedIterable|T) -> Iterable[tuple[list[int], Any]]:
+    """
+    Similar to flatten, except each entry also sends its location in the iterable.
+
+    A location value is a list of integer indexes assembled depth-first.
+    This value can be used to identify the position in the nested iterable.
+    The size of this list varies with the depth of the specific value.
+    """
+    if isinstance(iterable, Iterable):
+        for i, internal in enumerate(iterable):
+            for pos, v in enumerated_flatten(internal):
+                pos.append(i)
+                yield pos.copy(), v
+    else:
+        yield [], iterable
+
+def nested_index(sequence: NestedSequence|T, pos: list[int]) -> T|NestedSequence:
+    """
+    Looks up the element in a nested sequence by its location.
+    
+    The location list is defined the same as in nested_enumerate.
+    """
+    if len(pos) == 0:
+        return sequence
+    if not isinstance(sequence, Sequence):
+        raise IndexError("Maximum depth exceeded")
+    return nested_index(sequence[pos[-1]], pos[:-1])


### PR DESCRIPTION
Fixed a bug where the setting the flip state did not actually cause a flip to occur. This meant rotations were out-of-sync with the rest of the map leading to misaligned curves.

In addition the syntax for setting a flip state has been changed to accept a tuple of two booleans. The first describes the horizontal flipping, the second the vertical flipping. Vertical flipping is done by rotating the orientation by 180° and flipping the map horizontally (i. e. inverting the flag for horizontal flipping).

A new helper for flattening nested iterables has been added that simplifies one single triple-nested loop. (I swear I thought this was more important.)